### PR TITLE
Updating config tests: added a test case that checks if arrayOf can return errors in shapeOf or oneOf function call

### DIFF
--- a/packages/metal-state/src/validators.js
+++ b/packages/metal-state/src/validators.js
@@ -2,7 +2,6 @@
 
 import { getFunctionName, isDefAndNotNull } from 'metal';
 
-const ERROR_ARRAY_OF_TYPE = 'Expected an array of single type.';
 const ERROR_OBJECT_OF_TYPE = 'Expected object of one type.';
 const ERROR_ONE_OF = 'Expected one of the following values: ';
 const ERROR_ONE_OF_TYPE = 'Expected one of given types.';
@@ -227,7 +226,8 @@ function maybe(typeValidator) {
 function validateArrayItems(validator, value, name, context) {
 	for (let i = 0; i < value.length; i++) {
 		if (isInvalid(validator(value[i], name, context))) {
-			return composeError(ERROR_ARRAY_OF_TYPE, name, context);
+
+			return composeError(value[i], name, context);
 		}
 	}
 	return true;

--- a/packages/metal-state/src/validators.js
+++ b/packages/metal-state/src/validators.js
@@ -4,7 +4,7 @@ import { getFunctionName, isDefAndNotNull } from 'metal';
 
 const ERROR_ARRAY_OF_TYPE = 'Expected an array of single type.';
 const ERROR_OBJECT_OF_TYPE = 'Expected object of one type.';
-const ERROR_ONE_OF = 'Expected one of given values.';
+const ERROR_ONE_OF = 'Expected one of the following values: ';
 const ERROR_ONE_OF_TYPE = 'Expected one of given types.';
 const ERROR_SHAPE_OF = 'Expected object with a specific shape.';
 
@@ -83,8 +83,9 @@ const validators = {
 			if (isInvalid(result)) {
 				return result;
 			}
+			const message = ERROR_ONE_OF + arrayOfValues.join(', ') + '.';
 			return arrayOfValues.indexOf(value) === -1 ?
-				composeError(ERROR_ONE_OF, name, context) :
+				composeError(message, name, context) :
 				true;
 		});
 	},

--- a/packages/metal-state/src/validators.js
+++ b/packages/metal-state/src/validators.js
@@ -6,7 +6,6 @@ const ERROR_ARRAY_OF_TYPE = 'Expected an array of single type.';
 const ERROR_OBJECT_OF_TYPE = 'Expected object of one type.';
 const ERROR_ONE_OF = 'Expected one of the following values: ';
 const ERROR_ONE_OF_TYPE = 'Expected one of given types.';
-const ERROR_SHAPE_OF = 'Expected object with a specific shape.';
 
 /**
  * Provides access to various type validators that will return an
@@ -133,9 +132,9 @@ const validators = {
 					required = validator.config.required;
 					validator = validator.config.validator;
 				}
-				if ((required && !isDefAndNotNull(value[key])) ||
-					isInvalid(validator(value[key]))) {
-					return composeError(ERROR_SHAPE_OF, name, context);
+				if ((required && !isDefAndNotNull(value)) ||
+					isInvalid(validator(value))) {
+					return validator(value, name + '.' + key, context);
 				}
 			}
 			return true;

--- a/packages/metal-state/test/Config.js
+++ b/packages/metal-state/test/Config.js
@@ -141,17 +141,17 @@ describe('Config', function() {
 		assert.ok(core.isFunction(configShape.config.validator));
 
 		assert.ok(configShape.config.validator({ 
-		one: false,
-		two: 30,
-		three: 'anything',
+			one: false,
+			two: 30,
+			three: 'anything',
 		}) instanceof Error);
 
 		assert.ok(configShape.config.validator([1, 2]) instanceof Error);
 		assert.ok(configShape.config.validator({
-		one: false,
-		two: 'is String!',
-		three: 'propOne',
-		four: 30
+			one: false,
+			two: 'is String!',
+			three: 'propOne',
+			four: 30
 		}));
 	});
 

--- a/packages/metal-state/test/Config.js
+++ b/packages/metal-state/test/Config.js
@@ -124,6 +124,37 @@ describe('Config', function() {
 		assert.ok(config.config.validator(['one']) instanceof Error);
 	});
 
+	it('should return config with "arrayOf" validator inheriting "shapeOf" and "oneOf" from "validators"', function(){
+		var shape = {
+			one: Config.bool().value(false),
+			two: Config.string(),
+			three: Config.oneOf([
+				'propOne',
+				'propTwo',
+				'propThree'
+			]).value('propOne'),
+			four: Config.number().required()
+		};
+
+		var configShape = Config.arrayOf(Config.shapeOf(shape));
+		assert.ok(core.isObject(configShape));
+		assert.ok(core.isFunction(configShape.config.validator));
+
+		assert.ok(configShape.config.validator({ 
+		one: false,
+		two: 30,
+		three: 'anything',
+		}) instanceof Error);
+
+		assert.ok(configShape.config.validator([1, 2]) instanceof Error);
+		assert.ok(configShape.config.validator({
+		one: false,
+		two: 'is String!',
+		three: 'propOne',
+		four: 30
+		}));
+	});
+
 	it('should return config with "bool" validator from "validators"', function() {
 		var config = Config.bool();
 		assert.ok(core.isObject(config));


### PR DESCRIPTION
## oneOf:
>	Previously oneOf function returns a ‘composeError’ call with ‘constraint’ with a simple message, ‘name’ and ‘context’ as params and generate a message that should be modified. I realized that the value ‘arrayOfValues’ can give me expected values of ‘state’ and i’ve created a constraint called ‘message’ for ‘Expected one of the…’ constraint and joined a array formatting the values that can be expected. Finally i’ve replaced the constraint with ‘message’ const that i’ve created.

***

## shapeOf:
>	Previously shapeOf function returns a ‘composeError’ call with ‘constraint’ of shapeOf with a simple message and following attributes that i’ve explain in oneOf. I realized ‘value’ param can returns a invalid object that contains information about it. ‘validator()’ function can be called in this scope returning a error that others validators  inside shapeOf and overriding the message.

***

## arrayOf: 
>	In arrayOf function, for change the message, i’ve changed ‘validateArrayItems()’ function rather than returns a composeError call, will return a validator call in the same way of shapeOf changes.  

***

## Conclusion:
>	These methods returning simple messages about error on instantiate and now returns the possible values of their attributes. 

## PS:
>     @matuzalemteles, @brunobasto and me have verified some problems with current testing cases, a lot of asserts are skipping and anything that you type in them passes, probably “.ok” method of “assert” is causing this issue. We are examining some options.

cc @brunobasto, @matuzalemteles  
	
	